### PR TITLE
fix: pin tar to ^4.4.19 via npm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "redux": "^4.0.1",
     "uuid": "^3.3.2"
   },
+  "overrides": {
+    "tar": "^4.4.19"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
### Motivation
- Mitigate an arbitrary file read/write hardlink target escape via symlink-chain during `node-tar` extraction by ensuring a patched `tar` release is used for transitive dependencies.

### Description
- Add an `overrides` entry to `package.json` that forces `tar` to `^4.4.19`, causing npm to resolve a patched `tar` for transitive consumers without performing a broad dependency upgrade.

### Testing
- Confirmed the `overrides` entry is present with `node -e "const p=require('./package.json'); console.log(p.overrides.tar)"` which printed the pinned version (succeeded); ran `npm install --package-lock-only` which completed in this environment; attempted `npm install` and `npm view tar@4.4.19` but both failed with `403 Forbidden` due to registry access restrictions in the execution environment, preventing a full lockfile refresh and package fetch (not a failure of the change itself).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997d7c1a02083258144db101c270409)